### PR TITLE
fix(#66): ignore git config script if fail

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "lint": "eslint . --ext .ts --fix",
     "test": "jest --coverage",
     "build": "tsc",
-    "postinstall": "git config core.hooksPath .githooks",
-    "prepare": "git config core.hooksPath .githooks"
+    "postinstall": "git config core.hooksPath .githooks || true",
+    "prepare": "git config core.hooksPath .githooks || true"
   },
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
Exit 0 if postinstall/prepare scripts to install hooks fail.