### PR TITLE
fix(#496): use `valueAsDate` instead of `returnNativeDates`

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,12 +218,12 @@ Returns:
 ];
 ```
 
-You can opt-in to have the function return native JavaScript dates instead of strings for the `date` and `celebrationDate` properties by using the `returnNativeDate` option:
+You can opt-in to have the function return native JavaScript dates instead of strings for the `date` and `celebrationDate` properties by using the `valueAsDate` option:
 
 ```js
 const colombianHolidays2015 = colombianHolidays({
   year: 2015,
-  returnNativeDate: true,
+  valueAsDate: true,
 });
 ```
 
@@ -232,7 +232,7 @@ If the year is omitted, by default the function will return the holidays for the
 ```js
 const currentYearHolidaysAsStrings = colombianHolidays();
 const currentYearHolidaysAsDates = colombianHolidays({
-  returnNativeDate: true,
+  valueAsDate: true,
 });
 ```
 

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -61,22 +61,22 @@ function generateUtcStringFromDate(date: Date): string {
 
 function getHoliday(
   holiday: Holiday,
-  options?: { year?: number; returnNativeDate: false | undefined }
+  options?: { year?: number; valueAsDate: false | undefined }
 ): ColombianHoliday;
 function getHoliday(
   holiday: Holiday,
-  options: { year?: number; returnNativeDate: true }
+  options: { year?: number; valueAsDate: true }
 ): ColombianHolidayWithNativeDate;
 function getHoliday(
   holiday: Holiday,
-  options?: { year?: number; returnNativeDate?: boolean }
+  options?: { year?: number; valueAsDate?: boolean }
 ): ColombianHoliday | ColombianHolidayWithNativeDate;
 function getHoliday(
   holiday: Holiday,
   {
     year = new Date().getUTCFullYear(),
-    returnNativeDate = false,
-  }: { year?: number; returnNativeDate?: boolean } = {}
+    valueAsDate = false,
+  }: { year?: number; valueAsDate?: boolean } = {}
 ): unknown {
   const holidayDate = getHolidayDate(holiday, year);
   const celebrationDate =
@@ -85,10 +85,8 @@ function getHoliday(
       : holidayDate;
 
   return {
-    date: returnNativeDate
-      ? holidayDate
-      : generateUtcStringFromDate(holidayDate),
-    celebrationDate: returnNativeDate
+    date: valueAsDate ? holidayDate : generateUtcStringFromDate(holidayDate),
+    celebrationDate: valueAsDate
       ? celebrationDate
       : generateUtcStringFromDate(celebrationDate),
     name: holiday.name,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -479,7 +479,7 @@ describe.each(years)("Gets all holidays for %p", (year) => {
           const holidays = colombianHolidays({
             year,
             month,
-            returnNativeDate: true,
+            valueAsDate: true,
           });
           const expected = holidaysYears[year]
             .filter(
@@ -501,20 +501,20 @@ describe.each(years)("Gets all holidays for %p", (year) => {
   );
 
   it.each(timezones)(
-    "Should return holidays formatted as string for %p if returnNativeDate is set to false",
+    "Should return holidays formatted as string for %p if valueAsDate is set to false",
     (timezone) => {
       timezone_mock.register(timezone);
-      expect(colombianHolidays({ year, returnNativeDate: false })).toEqual(
+      expect(colombianHolidays({ year, valueAsDate: false })).toEqual(
         holidaysYears[year]
       );
     }
   );
 
   it.each(timezones)(
-    "Should return holidays with native JS date for %p if returnNativeDate is set to true",
+    "Should return holidays with native JS date for %p if valueAsDate is set to true",
     (timezone) => {
       timezone_mock.register(timezone);
-      expect(colombianHolidays({ year, returnNativeDate: true })).toEqual(
+      expect(colombianHolidays({ year, valueAsDate: true })).toEqual(
         holidaysYears[year].map(transformStringsToDates)
       );
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,26 +12,26 @@ export type Month = MonthNumbers | Omit<number, MonthNumbers>;
 export function colombianHolidays(
   options?:
     | undefined
-    | { year?: number; month?: Month; returnNativeDate: false | undefined }
+    | { year?: number; month?: Month; valueAsDate: false | undefined }
 ): ColombianHoliday[];
 export function colombianHolidays(options?: {
   year?: number;
   month?: Month;
-  returnNativeDate: true;
+  valueAsDate: true;
 }): ColombianHolidayWithNativeDate[];
 export function colombianHolidays(options?: {
   year?: number;
   month?: Month;
-  returnNativeDate?: boolean;
+  valueAsDate?: boolean;
 }): ColombianHoliday[] | ColombianHolidayWithNativeDate[];
 export function colombianHolidays({
   year = new Date().getUTCFullYear(),
   month,
-  returnNativeDate = false,
+  valueAsDate = false,
 }: {
   year?: number;
   month?: Month;
-  returnNativeDate?: boolean;
+  valueAsDate?: boolean;
 } = {}): unknown {
   if (year < FIRST_HOLIDAY_YEAR || year > LAST_HOLIDAY_YEAR) {
     throw new Error(
@@ -40,7 +40,7 @@ export function colombianHolidays({
   }
 
   return holidays
-    .map((holiday) => getHoliday(holiday, { year, returnNativeDate }))
+    .map((holiday) => getHoliday(holiday, { year, valueAsDate }))
     .filter((holiday) => {
       if (month === undefined) {
         return true;

--- a/src/utils/holidaysWithinInterval.test.ts
+++ b/src/utils/holidaysWithinInterval.test.ts
@@ -93,7 +93,7 @@ describe("holidaysWithinInterval", () => {
     const result = holidaysWithinInterval({
       start,
       end,
-      returnNativeDate: true,
+      valueAsDate: true,
     });
     expect(result.length).toBe(18);
     expect(result).toEqual(

--- a/src/utils/holidaysWithinInterval.ts
+++ b/src/utils/holidaysWithinInterval.ts
@@ -4,26 +4,26 @@ import { ColombianHoliday, ColombianHolidayWithNativeDate } from "../types";
 export function holidaysWithinInterval(options: {
   start: Date;
   end: Date;
-  returnNativeDate: false | undefined;
+  valueAsDate: false | undefined;
 }): ColombianHoliday[];
 export function holidaysWithinInterval(options: {
   start: Date;
   end: Date;
-  returnNativeDate: true;
+  valueAsDate: true;
 }): ColombianHolidayWithNativeDate[];
 export function holidaysWithinInterval(options: {
   start: Date;
   end: Date;
-  returnNativeDate?: boolean;
+  valueAsDate?: boolean;
 }): ColombianHoliday[] | ColombianHolidayWithNativeDate[];
 export function holidaysWithinInterval({
   start,
   end,
-  returnNativeDate = false,
+  valueAsDate = false,
 }: {
   start: Date;
   end: Date;
-  returnNativeDate?: boolean;
+  valueAsDate?: boolean;
 }): unknown {
   if (start >= end) {
     throw new Error("end date should be greater than start date");
@@ -32,7 +32,7 @@ export function holidaysWithinInterval({
   const yearStart = start.getUTCFullYear();
 
   const holidays = Array.from({ length: yearEnd - yearStart + 1 }, (_, i) =>
-    colombianHolidays({ year: i + yearStart, returnNativeDate })
+    colombianHolidays({ year: i + yearStart, valueAsDate })
   ).flat();
 
   return holidays.filter(({ celebrationDate }) => {


### PR DESCRIPTION
closes #496