### PR TITLE
feat: agrega el festivo Día de Nuestra Señora del Rosario de Chiquinquirá (Ley 2578 de 2026)

### DIFF
--- a/src/holidays.ts
+++ b/src/holidays.ts
@@ -33,6 +33,12 @@ const dateHolidays: DateHoliday[] = [
 	},
 	{
 		month: 7,
+		day: 9,
+		name: "Día de Nuestra Señora del Rosario de Chiquinquirá",
+		nextMonday: true,
+	},
+	{
+		month: 7,
 		day: 20,
 		name: "Grito de la Independencia",
 		nextMonday: false,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -66,6 +66,12 @@ const holidaysYears: Record<number, ColombianHoliday[]> = {
 			nextMonday: false,
 		},
 		{
+			date: "1976-07-09",
+			celebrationDate: "1976-07-09",
+			name: "Día de Nuestra Señora del Rosario de Chiquinquirá",
+			nextMonday: false,
+		},
+		{
 			date: "1976-07-20",
 			celebrationDate: "1976-07-20",
 			name: "Grito de la Independencia",
@@ -173,6 +179,12 @@ const holidaysYears: Record<number, ColombianHoliday[]> = {
 			date: "1983-06-29",
 			celebrationDate: "1983-06-29",
 			name: "San Pedro y San Pablo",
+			nextMonday: false,
+		},
+		{
+			date: "1983-07-09",
+			celebrationDate: "1983-07-09",
+			name: "Día de Nuestra Señora del Rosario de Chiquinquirá",
 			nextMonday: false,
 		},
 		{
@@ -286,6 +298,12 @@ const holidaysYears: Record<number, ColombianHoliday[]> = {
 			nextMonday: true,
 		},
 		{
+			date: "2015-07-09",
+			celebrationDate: "2015-07-13",
+			name: "Día de Nuestra Señora del Rosario de Chiquinquirá",
+			nextMonday: true,
+		},
+		{
 			date: "2015-07-20",
 			celebrationDate: "2015-07-20",
 			name: "Grito de la Independencia",
@@ -396,6 +414,12 @@ const holidaysYears: Record<number, ColombianHoliday[]> = {
 			nextMonday: true,
 		},
 		{
+			date: "2018-07-09",
+			celebrationDate: "2018-07-09",
+			name: "Día de Nuestra Señora del Rosario de Chiquinquirá",
+			nextMonday: true,
+		},
+		{
 			date: "2018-07-20",
 			celebrationDate: "2018-07-20",
 			name: "Grito de la Independencia",
@@ -497,7 +521,7 @@ describe("Gets all holidays for the current year", () => {
 	it("Should return holidays for the current year", () => {
 		const currYear = new Date().getFullYear();
 		const currHols = getHolidaysByYear(currYear);
-		const holidaysInAYear = 18;
+		const holidaysInAYear = 19;
 		expect(Array.isArray(currHols)).toBe(true);
 		expect(currHols.length).toBe(holidaysInAYear);
 	});
@@ -515,7 +539,7 @@ describe("Gets all holidays for the current year", () => {
 		it("Should return holidays for the current year", () => {
 			const currYear = new Date().getFullYear();
 			const currHols = getHolidaysByYear(currYear);
-			const holidaysInAYear = 18;
+			const holidaysInAYear = 19;
 			expect(Array.isArray(currHols)).toBe(true);
 			expect(currHols.length).toBe(holidaysInAYear);
 		});

--- a/src/utils/holidaysWithinInterval.test.ts
+++ b/src/utils/holidaysWithinInterval.test.ts
@@ -77,7 +77,7 @@ describe("holidaysWithinInterval", () => {
 		const end = new Date("2021-12-31");
 		const result = holidaysWithinInterval({ start, end });
 
-		expect(result.length).toBe(18);
+		expect(result.length).toBe(19);
 		expect(result).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({
@@ -96,7 +96,7 @@ describe("holidaysWithinInterval", () => {
 			end,
 			valueAsDate: true,
 		});
-		expect(result.length).toBe(18);
+		expect(result.length).toBe(19);
 		expect(result).toEqual(
 			expect.arrayContaining([
 				expect.objectContaining({
@@ -112,6 +112,6 @@ describe("holidaysWithinInterval", () => {
 		const end = new Date("2016-03-25");
 		const result = holidaysWithinInterval({ start, end });
 
-		expect(result.length).toBe(31);
+		expect(result.length).toBe(32);
 	});
 });


### PR DESCRIPTION
## Resumen

Agrega el nuevo festivo nacional **Día de Nuestra Señora del Rosario de Chiquinquirá** (9 de julio), creado por la [Ley 2578 del 1 de junio de 2026](https://www.mininterior.gov.co/noticias/gobierno-sanciona-ley-que-convierte-el-9-de-julio-en-nuevo-festivo-nacional/).

Al festivo le aplica la Ley Emiliani (`nextMonday: true`): cuando el 9 de julio no cae lunes, el descanso se traslada al lunes siguiente. Por ejemplo, en 2026 (jueves 9 de julio) se celebra el lunes 13 de julio.

## Cambios

- `src/holidays.ts`: se agrega el festivo a `dateHolidays` (mes 7, día 9, `nextMonday: true`).
- `src/index.test.ts`: se actualizan los fixtures de 1976, 1983 (antes de 1984, sin traslado), 2015 (jueves 9 → lunes 13) y 2018 (cae lunes, se celebra el mismo día), y el conteo de festivos por año pasa de 18 a 19.
- `src/utils/holidaysWithinInterval.test.ts`: conteos actualizados (18 → 19 para un año completo, 31 → 32 para el intervalo 2014-2016).

## Nota

La librería no restringe los festivos por año de entrada en vigencia (todos aplican en el rango completo 1583–4099), así que seguí esa misma convención: el festivo aparece también en años anteriores a 2026. Si prefieres manejar la vigencia por año, con gusto ajusto la PR.

## Verificación

- `vitest run`: 125 tests pasan (4 archivos).
